### PR TITLE
feat: improve pot creation behaviour

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,10 +57,12 @@ model Pot {
   updatedAt DateTime @updatedAt
   user      User     @relation(fields: [userId], references: [id])
   userId    String
-  name      String   @unique
+  name      String
   target    Decimal  @db.Decimal(12, 2)
   color     Color    @relation(fields: [colorId], references: [id])
   colorId   String
+
+  @@unique([userId, name])
 }
 
 model Transaction {

--- a/src/actions/pots.ts
+++ b/src/actions/pots.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { revalidatePath } from "next/cache"
 import * as z from "zod"
 
 import * as pots from "@/data-access/pots"
@@ -17,5 +18,6 @@ export async function createNewPot(
   const response = await pots.createNewPot(formData)
   if (!response.success) return response.fieldErrors
 
+  revalidatePath("/login")
   return null
 }

--- a/src/app/(dashboard)/pots/page.tsx
+++ b/src/app/(dashboard)/pots/page.tsx
@@ -17,7 +17,7 @@ export default async function PotsPage() {
         </Heading>
         <NewPotDialog colors={colors} />
       </div>
-      <div>
+      <div className="grid gap-6 lg:grid-cols-2">
         {pots.map(({ id, name, target, color }) => (
           <PotCard
             key={id}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -55,6 +55,7 @@ export default function LoginForm() {
                   {...field}
                   isInvalid={invalid}
                   errorMessage={error?.message}
+                  isDisabled={isSubmitting}
                 />
               )}
             />
@@ -69,6 +70,7 @@ export default function LoginForm() {
                   {...field}
                   isInvalid={invalid}
                   errorMessage={error?.message}
+                  isDisabled={isSubmitting}
                 />
               )}
             />

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -55,6 +55,7 @@ export default function SignupForm() {
                   {...field}
                   isInvalid={invalid}
                   errorMessage={error?.message}
+                  isDisabled={isSubmitting}
                 />
               )}
             />
@@ -68,6 +69,7 @@ export default function SignupForm() {
                   {...field}
                   isInvalid={invalid}
                   errorMessage={error?.message}
+                  isDisabled={isSubmitting}
                 />
               )}
             />
@@ -83,6 +85,7 @@ export default function SignupForm() {
                   isInvalid={invalid}
                   errorMessage={error?.message}
                   description="Password must be at least 8 characters"
+                  isDisabled={isSubmitting}
                 />
               )}
             />

--- a/src/components/pots/NewPotDialog.tsx
+++ b/src/components/pots/NewPotDialog.tsx
@@ -28,96 +28,99 @@ export default function NewPotDialog({ colors }: { colors: Colors }) {
     <DialogTrigger>
       <Button variant="primary">+ Add New Pot</Button>
       <Dialog title="Add New Pot">
-        <form
-          className="grid gap-5"
-          onSubmit={handleSubmit(async (data) => {
-            const response = await createNewPot(data)
-            if (response) {
-              const errorKeys = Object.keys(
-                response
-              ) as (keyof CreateNewPotErrors)[]
-              errorKeys.forEach((key) =>
-                setError(
-                  key,
-                  { message: response[key]?.[0] },
-                  { shouldFocus: true }
+        {({ close }) => (
+          <form
+            className="grid gap-5"
+            onSubmit={handleSubmit(async (data) => {
+              const response = await createNewPot(data)
+              if (response) {
+                const errorKeys = Object.keys(
+                  response
+                ) as (keyof CreateNewPotErrors)[]
+                errorKeys.forEach((key) =>
+                  setError(
+                    key,
+                    { message: response[key]?.[0] },
+                    { shouldFocus: true }
+                  )
                 )
-              )
-            }
-          })}
-        >
-          <p className="text-grey-500 text-sm leading-normal font-normal">
-            Create a pot to set savings targets. These can help keep you on
-            track as you save for special purchases.
-          </p>
-          <div className="grid gap-4">
-            <Controller
-              name="name"
-              control={control}
-              render={({ field, fieldState: { invalid, error } }) => (
-                <TextField
-                  label="Pot Name"
-                  placeholder="e.g. Rainy Days"
-                  description="Max 30 characters"
-                  {...field}
-                  isInvalid={invalid}
-                  errorMessage={error?.message}
-                  isDisabled={isSubmitting}
-                />
-              )}
-            />
-            <Controller
-              name="target"
-              control={control}
-              render={({ field, fieldState: { invalid, error } }) => (
-                <TextField
-                  label="Target"
-                  placeholder="e.g. 2000"
-                  {...field}
-                  isInvalid={invalid}
-                  errorMessage={error?.message}
-                  isDisabled={isSubmitting}
-                />
-              )}
-            />
-            <Controller
-              name="theme"
-              control={control}
-              render={({
-                field: { name, value, onChange, ref },
-                fieldState: { invalid, error },
-              }) => (
-                <Select
-                  label="Theme"
-                  placeholder="Select a color"
-                  name={name}
-                  selectedKey={value}
-                  onSelectionChange={(selected) => onChange(selected)}
-                  ref={ref}
-                  isInvalid={invalid}
-                  isDisabled={isSubmitting}
-                  errorMessage={error?.message}
-                  items={colors}
-                >
-                  {(item) => (
-                    <SelectItem textValue={item.label}>
-                      <div className="flex items-center justify-start gap-3">
-                        <span
-                          className="size-4 rounded-full"
-                          style={{ backgroundColor: item.value }}
-                        />
-                        <span>{item.label}</span>
-                      </div>
-                    </SelectItem>
-                  )}
-                </Select>
-              )}
-            />
-          </div>
-          <Button variant="primary" type="submit" isPending={isSubmitting}>
-            Add Pot
-          </Button>
-        </form>
+              }
+              close()
+            })}
+          >
+            <p className="text-grey-500 text-sm leading-normal font-normal">
+              Create a pot to set savings targets. These can help keep you on
+              track as you save for special purchases.
+            </p>
+            <div className="grid gap-4">
+              <Controller
+                name="name"
+                control={control}
+                render={({ field, fieldState: { invalid, error } }) => (
+                  <TextField
+                    label="Pot Name"
+                    placeholder="e.g. Rainy Days"
+                    description="Max 30 characters"
+                    {...field}
+                    isInvalid={invalid}
+                    errorMessage={error?.message}
+                    isDisabled={isSubmitting}
+                  />
+                )}
+              />
+              <Controller
+                name="target"
+                control={control}
+                render={({ field, fieldState: { invalid, error } }) => (
+                  <TextField
+                    label="Target"
+                    placeholder="e.g. 2000"
+                    {...field}
+                    isInvalid={invalid}
+                    errorMessage={error?.message}
+                    isDisabled={isSubmitting}
+                  />
+                )}
+              />
+              <Controller
+                name="theme"
+                control={control}
+                render={({
+                  field: { name, value, onChange, ref },
+                  fieldState: { invalid, error },
+                }) => (
+                  <Select
+                    label="Theme"
+                    placeholder="Select a color"
+                    name={name}
+                    selectedKey={value}
+                    onSelectionChange={(selected) => onChange(selected)}
+                    ref={ref}
+                    isInvalid={invalid}
+                    isDisabled={isSubmitting}
+                    errorMessage={error?.message}
+                    items={colors}
+                  >
+                    {(item) => (
+                      <SelectItem textValue={item.label}>
+                        <div className="flex items-center justify-start gap-3">
+                          <span
+                            className="size-4 rounded-full"
+                            style={{ backgroundColor: item.value }}
+                          />
+                          <span>{item.label}</span>
+                        </div>
+                      </SelectItem>
+                    )}
+                  </Select>
+                )}
+              />
+            </div>
+            <Button variant="primary" type="submit" isPending={isSubmitting}>
+              Add Pot
+            </Button>
+          </form>
+        )}
       </Dialog>
     </DialogTrigger>
   )

--- a/src/components/pots/NewPotDialog.tsx
+++ b/src/components/pots/NewPotDialog.tsx
@@ -18,6 +18,7 @@ export default function NewPotDialog({ colors }: { colors: Colors }) {
     handleSubmit,
     control,
     setError,
+    reset,
     formState: { isSubmitting },
   } = useForm({
     resolver: zodResolver(potSchema),
@@ -44,7 +45,9 @@ export default function NewPotDialog({ colors }: { colors: Colors }) {
                     { shouldFocus: true }
                   )
                 )
+                return
               }
+              reset()
               close()
             })}
           >

--- a/src/components/ui/Dialog.stories.tsx
+++ b/src/components/ui/Dialog.stories.tsx
@@ -30,6 +30,10 @@ const meta = {
         type: { summary: '"dialog" | "alertdialog"' },
       },
     },
+    children: {
+      control: { disable: true },
+      table: { type: { summary: "ReactNode | ({close}) => ReactNode" } },
+    },
   },
 } satisfies Meta<typeof Dialog>
 

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -8,6 +8,7 @@ import {
   Dialog as RacDialog,
   Heading as RacHeading,
   type ModalOverlayProps as RacModalOverlayProps,
+  type DialogRenderProps as RacDialogRenderProps,
 } from "react-aria-components"
 
 import Card from "@/components/ui/Card"
@@ -28,7 +29,7 @@ function Dialog({
   ...props
 }: Omit<RacModalOverlayProps, "children"> & {
   title: string
-  children?: ReactNode
+  children?: ReactNode | ((opts: RacDialogRenderProps) => ReactNode)
   role?: "dialog" | "alertdialog"
 }) {
   return (
@@ -43,18 +44,22 @@ function Dialog({
         className="w-full max-w-[35rem]"
       >
         <RacDialog className="outline-none" role={role}>
-          <Card theme="light" padding="lg">
-            <div className="mb-6 flex items-center justify-between gap-2 md:mb-5">
-              <RacHeading
-                slot="title"
-                className="text-grey-900 text-xl leading-tight font-bold md:text-3xl"
-              >
-                {title}
-              </RacHeading>
-              <IconButton variant="close" slot="close" />
-            </div>
-            {children}
-          </Card>
+          {(dialogRenderProps) => (
+            <Card theme="light" padding="lg">
+              <div className="mb-6 flex items-center justify-between gap-2 md:mb-5">
+                <RacHeading
+                  slot="title"
+                  className="text-grey-900 text-xl leading-tight font-bold md:text-3xl"
+                >
+                  {title}
+                </RacHeading>
+                <IconButton variant="close" slot="close" />
+              </div>
+              {typeof children === "function"
+                ? children(dialogRenderProps)
+                : children}
+            </Card>
+          )}
         </RacDialog>
       </MotionRacModal>
     </RacModalOverlay>

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -43,7 +43,7 @@ const navbarStyles = tv({
   variants: {
     isExpanded: {
       true: {
-        nav: "lg:w-75",
+        nav: "lg:w-70",
         logoDivSmall: "lg:hidden",
         logoDivLarge: "lg:block",
         buttonSpan: "lg:block",


### PR DESCRIPTION
- Passed `isSubmitting` from RHF as the value to `isDisabled` prop on each field on the auth forms (Login and Signup) so the fields are disbaled when form is being submitted.
- Prisma schema was setup to force pot names to be unique across all users. Updated the schema so that pot names are only unique for each user. So now same pot name can be used by two users.
- Reduced navbar width to give more space to the main content area.
- After creating a new pot, refreshed the route with revalidatePath, closed the dialog, and reset the form.