### PR TITLE
refactor: select component styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,3 +62,19 @@
     -webkit-appearance: none;
   }
 }
+
+@layer components {
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--color-grey-300);
+    border-radius: 16px;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+}

--- a/src/components/recurring-bills/TableFilters.tsx
+++ b/src/components/recurring-bills/TableFilters.tsx
@@ -50,7 +50,7 @@ export default function TableFilters() {
         selectedKey={readOnlySearchParams.get("sortby") ?? "latest"}
         onSelectionChange={onSortByChange}
         shouldHideOnMobile
-        className="size-5 max-w-62 md:h-full md:w-full md:min-w-50"
+        className="max-w-62 md:h-full md:w-full md:min-w-50"
       >
         <SelectItem id="latest">Latest</SelectItem>
         <SelectItem id="oldest">Oldest</SelectItem>

--- a/src/components/recurring-bills/TableFilters.tsx
+++ b/src/components/recurring-bills/TableFilters.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { usePathname, useSearchParams, useRouter } from "next/navigation"
+import { PiSortAscendingFill } from "react-icons/pi"
 import { useDebouncedCallback } from "use-debounce"
 
 import SearchField from "@/components/ui/SearchField"
@@ -51,6 +52,7 @@ export default function TableFilters() {
         onSelectionChange={onSortByChange}
         shouldHideOnMobile
         className="max-w-62 md:h-full md:w-full md:min-w-50"
+        mobileIcon={PiSortAscendingFill}
       >
         <SelectItem id="latest">Latest</SelectItem>
         <SelectItem id="oldest">Oldest</SelectItem>

--- a/src/components/recurring-bills/TableFilters.tsx
+++ b/src/components/recurring-bills/TableFilters.tsx
@@ -50,7 +50,7 @@ export default function TableFilters() {
         selectedKey={readOnlySearchParams.get("sortby") ?? "latest"}
         onSelectionChange={onSortByChange}
         shouldHideOnMobile
-        className="size-5 max-w-62 sm:w-full sm:min-w-50"
+        className="size-5 max-w-62 sm:w-full sm:min-w-50 md:h-full"
       >
         <SelectItem id="latest">Latest</SelectItem>
         <SelectItem id="oldest">Oldest</SelectItem>

--- a/src/components/recurring-bills/TableFilters.tsx
+++ b/src/components/recurring-bills/TableFilters.tsx
@@ -35,7 +35,7 @@ export default function TableFilters() {
   }
 
   return (
-    <div className="flex items-center justify-between gap-6 sm:items-start">
+    <div className="flex items-center justify-between gap-6 md:items-start">
       <SearchField
         placeholder="Search Bills"
         label="Search Recurring Bills"
@@ -50,7 +50,7 @@ export default function TableFilters() {
         selectedKey={readOnlySearchParams.get("sortby") ?? "latest"}
         onSelectionChange={onSortByChange}
         shouldHideOnMobile
-        className="size-5 max-w-62 sm:w-full sm:min-w-50 md:h-full"
+        className="size-5 max-w-62 md:h-full md:w-full md:min-w-50"
       >
         <SelectItem id="latest">Latest</SelectItem>
         <SelectItem id="oldest">Oldest</SelectItem>

--- a/src/components/transactions/TableFilters.tsx
+++ b/src/components/transactions/TableFilters.tsx
@@ -68,7 +68,7 @@ export default function TableFilters({
           selectedKey={readOnlySearchParams.get("sortby") ?? "latest"}
           onSelectionChange={onSortByChange}
           shouldHideOnMobile
-          className="size-5 max-w-62 md:h-full md:w-full md:min-w-50"
+          className="max-w-62 md:h-full md:w-full md:min-w-50"
         >
           <SelectItem id="latest">Latest</SelectItem>
           <SelectItem id="oldest">Oldest</SelectItem>
@@ -84,7 +84,7 @@ export default function TableFilters({
           selectedKey={readOnlySearchParams.get("category") ?? "all"}
           onSelectionChange={onCategoryChange}
           shouldHideOnMobile
-          className="size-5 max-w-70 md:h-full md:w-full md:min-w-55"
+          className="max-w-70 md:h-full md:w-full md:min-w-55"
           items={categoriesWithAll}
         >
           {(category) => (

--- a/src/components/transactions/TableFilters.tsx
+++ b/src/components/transactions/TableFilters.tsx
@@ -68,7 +68,7 @@ export default function TableFilters({
           selectedKey={readOnlySearchParams.get("sortby") ?? "latest"}
           onSelectionChange={onSortByChange}
           shouldHideOnMobile
-          className="size-5 max-w-62 sm:w-full sm:min-w-50"
+          className="size-5 max-w-62 sm:h-full sm:w-full sm:min-w-50"
         >
           <SelectItem id="latest">Latest</SelectItem>
           <SelectItem id="oldest">Oldest</SelectItem>
@@ -84,7 +84,7 @@ export default function TableFilters({
           selectedKey={readOnlySearchParams.get("category") ?? "all"}
           onSelectionChange={onCategoryChange}
           shouldHideOnMobile
-          className="size-5 max-w-70 sm:w-full sm:min-w-55"
+          className="size-5 max-w-70 sm:h-full sm:w-full sm:min-w-55"
           items={categoriesWithAll}
         >
           {(category) => (

--- a/src/components/transactions/TableFilters.tsx
+++ b/src/components/transactions/TableFilters.tsx
@@ -53,7 +53,7 @@ export default function TableFilters({
   }
 
   return (
-    <div className="flex items-center justify-between gap-6 sm:items-start">
+    <div className="flex items-center justify-between gap-6 md:items-start">
       <SearchField
         placeholder="Search Transactions"
         label="Search Transactions"
@@ -61,14 +61,14 @@ export default function TableFilters({
         defaultValue={readOnlySearchParams.get("query") ?? ""}
         onChange={onSearchChange}
       />
-      <div className="flex items-start justify-end gap-6 sm:w-full">
+      <div className="flex items-start justify-end gap-6 md:w-full">
         <Select
           label="Sort by"
           aria-label="Sort by"
           selectedKey={readOnlySearchParams.get("sortby") ?? "latest"}
           onSelectionChange={onSortByChange}
           shouldHideOnMobile
-          className="size-5 max-w-62 sm:h-full sm:w-full sm:min-w-50"
+          className="size-5 max-w-62 md:h-full md:w-full md:min-w-50"
         >
           <SelectItem id="latest">Latest</SelectItem>
           <SelectItem id="oldest">Oldest</SelectItem>
@@ -84,7 +84,7 @@ export default function TableFilters({
           selectedKey={readOnlySearchParams.get("category") ?? "all"}
           onSelectionChange={onCategoryChange}
           shouldHideOnMobile
-          className="size-5 max-w-70 sm:h-full sm:w-full sm:min-w-55"
+          className="size-5 max-w-70 md:h-full md:w-full md:min-w-55"
           items={categoriesWithAll}
         >
           {(category) => (

--- a/src/components/transactions/TableFilters.tsx
+++ b/src/components/transactions/TableFilters.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { PiSortAscendingFill, PiFunnelFill } from "react-icons/pi"
 import { useDebouncedCallback } from "use-debounce"
 
 import SearchField from "@/components/ui/SearchField"
@@ -69,6 +70,7 @@ export default function TableFilters({
           onSelectionChange={onSortByChange}
           shouldHideOnMobile
           className="max-w-62 md:h-full md:w-full md:min-w-50"
+          mobileIcon={PiSortAscendingFill}
         >
           <SelectItem id="latest">Latest</SelectItem>
           <SelectItem id="oldest">Oldest</SelectItem>
@@ -86,6 +88,7 @@ export default function TableFilters({
           shouldHideOnMobile
           className="max-w-70 md:h-full md:w-full md:min-w-55"
           items={categoriesWithAll}
+          mobileIcon={PiFunnelFill}
         >
           {(category) => (
             <SelectItem id={category.name}>{category.label}</SelectItem>

--- a/src/components/ui/Select.stories.tsx
+++ b/src/components/ui/Select.stories.tsx
@@ -17,7 +17,6 @@ const meta = {
     isDisabled: false,
   },
   argTypes: {
-    layout: { control: "select", options: ["horizontal", "vertical"] },
     labelVariant: { control: "select", options: ["primary", "secondary"] },
     items: { table: { disable: true } },
     children: { table: { disable: true } },
@@ -42,9 +41,6 @@ export const Default: Story = {
 }
 
 export const HorizontalLayout: Story = {
-  args: {
-    layout: "horizontal",
-  },
   render: (args) => (
     <Select {...args}>
       <SelectItem>Apple</SelectItem>

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -34,7 +34,7 @@ const selectStyles = tv({
     fieldDescription: "",
     fieldErrorMessage: "",
     button:
-      "rac-focus-visible:ring-2 group rac-disabled:opacity-40 text-grey-900 ring-beige-500 group-rac-invalid:ring-red cursor-pointer outline-none sm:w-full",
+      "rac-focus-visible:ring-2 group rac-disabled:opacity-40 text-grey-900 ring-beige-500 group-rac-invalid:ring-red cursor-pointer outline-none md:w-full",
     buttonSpan:
       "border-beige-500 group-rac-invalid:border-red w-full items-center justify-between gap-2 rounded-lg border px-5 py-3 text-start text-sm leading-normal font-normal",
     mobileIcon: "size-5",
@@ -45,14 +45,13 @@ const selectStyles = tv({
   variants: {
     shouldHideOnMobile: {
       true: {
-        innerWrapper: "grid-cols-1 [grid-template-areas:none]",
-        fieldLabel: "sr-only sm:not-sr-only",
-        fieldDescription: "sr-only sm:not-sr-only",
-        fieldErrorMessage: "sr-only sm:not-sr-only",
-        button: "rounded sm:rounded-lg",
-        buttonSpan: "hidden sm:flex",
-        mobileIcon: "block sm:hidden",
-        popoverDiv: "min-w-50 sm:max-w-full",
+        fieldLabel: "sr-only md:not-sr-only",
+        fieldDescription: "sr-only md:not-sr-only",
+        fieldErrorMessage: "sr-only md:not-sr-only",
+        button: "rounded md:rounded-lg",
+        buttonSpan: "hidden md:flex",
+        mobileIcon: "block md:hidden",
+        popoverDiv: "min-w-50 md:max-w-full",
       },
       false: {
         mobileIcon: "hidden",

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -37,7 +37,7 @@ const selectStyles = tv({
       "rac-focus-visible:ring-2 group rac-disabled:opacity-40 text-grey-900 ring-beige-500 group-rac-invalid:ring-red cursor-pointer outline-none md:w-full",
     buttonSpan:
       "border-beige-500 group-rac-invalid:border-red w-full items-center justify-between gap-2 rounded-lg border px-5 py-3 text-start text-sm leading-normal font-normal",
-    mobileIcon: "size-5",
+    mobileIcon: "size-8",
     popoverDiv:
       "border-grey-200 custom-scrollbar max-h-80 w-(--trigger-width) overflow-auto rounded-lg border bg-white px-1 py-1 shadow-xl",
   },

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -28,11 +28,11 @@ const MotionPiCaretDownFill = motion.create(PiCaretDownFill)
 
 const selectStyles = tv({
   slots: {
-    select: "group",
-    layoutWrapper: "grid gap-x-2 gap-y-1",
-    fieldLabel: "self-center",
-    fieldDescription: "[grid-area:c]",
-    fieldErrorMessage: "[grid-area:c]",
+    outerWrapper: "group",
+    innerWrapper: "grid justify-items-start gap-1",
+    fieldLabel: "",
+    fieldDescription: "",
+    fieldErrorMessage: "",
     button:
       "rac-focus-visible:ring-2 group rac-disabled:opacity-40 text-grey-900 ring-beige-500 group-rac-invalid:ring-red cursor-pointer outline-none sm:w-full",
     buttonSpan:
@@ -43,20 +43,9 @@ const selectStyles = tv({
   },
 
   variants: {
-    layout: {
-      vertical: {
-        layoutWrapper:
-          "justify-items-start [grid-template-areas:'a''b''c'] sm:[grid-template-areas:'a''b''c']",
-      },
-      horizontal: {
-        layoutWrapper:
-          "grid-cols-[auto_1fr] [grid-template-areas:'a_b''a_c'] sm:grid-cols-[auto_1fr] sm:[grid-template-areas:'a_b''a_c']",
-      },
-    },
-
     shouldHideOnMobile: {
       true: {
-        layoutWrapper: "grid-cols-1 [grid-template-areas:none]",
+        innerWrapper: "grid-cols-1 [grid-template-areas:none]",
         fieldLabel: "sr-only sm:not-sr-only",
         fieldDescription: "sr-only sm:not-sr-only",
         fieldErrorMessage: "sr-only sm:not-sr-only",
@@ -73,15 +62,12 @@ const selectStyles = tv({
     },
   },
 
-  defaultVariants: {
-    layout: "vertical",
-    shouldHideOnMobile: false,
-  },
+  defaultVariants: { shouldHideOnMobile: false },
 })
 
 const {
-  select,
-  layoutWrapper,
+  outerWrapper,
+  innerWrapper,
   fieldLabel,
   button,
   buttonSpan,
@@ -114,7 +100,6 @@ function Select<T extends object>({
   errorMessage,
   isInvalid,
   items,
-  layout,
   shouldHideOnMobile,
   children,
   ref,
@@ -125,12 +110,12 @@ function Select<T extends object>({
     <RacSelect
       isInvalid={isInvalid}
       {...props}
-      className={select({ className })}
+      className={outerWrapper({ className })}
       ref={ref}
     >
       {({ isOpen }) => (
         <>
-          <div className={layoutWrapper({ layout, shouldHideOnMobile })}>
+          <div className={innerWrapper({ shouldHideOnMobile })}>
             <Label
               variant={labelVariant}
               className={fieldLabel({ shouldHideOnMobile })}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -23,6 +23,7 @@ import FieldError from "@/components/ui/FieldError"
 import Label, { type LabelVariants } from "@/components/ui/Label"
 
 import type { ReactNode, Ref } from "react"
+import type { IconType } from "react-icons"
 
 const MotionPiCaretDownFill = motion.create(PiCaretDownFill)
 
@@ -37,7 +38,7 @@ const selectStyles = tv({
       "rac-focus-visible:ring-2 group rac-disabled:opacity-40 text-grey-900 ring-beige-500 group-rac-invalid:ring-red cursor-pointer outline-none md:w-full",
     buttonSpan:
       "border-beige-500 group-rac-invalid:border-red w-full items-center justify-between gap-2 rounded-lg border px-5 py-3 text-start text-sm leading-normal font-normal",
-    mobileIcon: "size-8",
+    mobileIconStyles: "size-8",
     popoverDiv:
       "border-grey-200 custom-scrollbar max-h-80 w-(--trigger-width) overflow-auto rounded-lg border bg-white px-1 py-1 shadow-xl",
   },
@@ -50,7 +51,7 @@ const selectStyles = tv({
         fieldErrorMessage: "sr-only md:not-sr-only",
         button: "rounded md:rounded-lg",
         buttonSpan: "hidden md:flex",
-        mobileIcon: "block md:hidden",
+        mobileIconStyles: "block md:hidden",
         popoverDiv: "min-w-50 md:max-w-full",
       },
       false: {
@@ -70,7 +71,7 @@ const {
   fieldLabel,
   button,
   buttonSpan,
-  mobileIcon,
+  mobileIconStyles,
   popoverDiv,
   fieldDescription,
   fieldErrorMessage,
@@ -90,6 +91,7 @@ type SelectProps<T extends object> = Omit<
   children?: ReactNode | ((item: T) => ReactNode)
   ref?: Ref<HTMLDivElement>
   className?: string
+  mobileIcon?: IconType
 } & SelectStyles
 
 function Select<T extends object>({
@@ -103,6 +105,7 @@ function Select<T extends object>({
   children,
   ref,
   className,
+  mobileIcon: MobileIcon = PiSortAscendingFill,
   ...props
 }: SelectProps<T>) {
   return (
@@ -139,8 +142,8 @@ function Select<T extends object>({
                   }}
                 />
               </span>
-              <PiSortAscendingFill
-                className={mobileIcon({ shouldHideOnMobile })}
+              <MobileIcon
+                className={mobileIconStyles({ shouldHideOnMobile })}
               />
             </RacButton>
 

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -11,8 +11,11 @@ import {
   type SelectProps as RacSelectProps,
   type ListBoxItemProps as RacListBoxItemProps,
 } from "react-aria-components"
-import { FaCheck } from "react-icons/fa6"
-import { PiCaretDownFill, PiSortAscendingFill } from "react-icons/pi"
+import {
+  PiCheckBold,
+  PiCaretDownFill,
+  PiSortAscendingFill,
+} from "react-icons/pi"
 import { tv, type VariantProps } from "tailwind-variants"
 
 import FieldDescription from "@/components/ui/FieldDescription"
@@ -209,7 +212,7 @@ function SelectItem({
         <div className="flex w-full items-center justify-between gap-6">
           {children}
           {isSelected && (
-            <FaCheck className="text-grey-500 size-3.5 shrink-0" />
+            <PiCheckBold className="text-grey-500 size-4 shrink-0" />
           )}
         </div>
       )}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -39,7 +39,7 @@ const selectStyles = tv({
       "border-beige-500 group-rac-invalid:border-red w-full items-center justify-between gap-2 rounded-lg border px-5 py-3 text-start text-sm leading-normal font-normal",
     mobileIcon: "size-5",
     popoverDiv:
-      "border-grey-200 max-h-80 w-(--trigger-width) overflow-auto rounded-lg border bg-white px-1 py-1 shadow-xl",
+      "border-grey-200 custom-scrollbar max-h-80 w-(--trigger-width) overflow-auto rounded-lg border bg-white px-1 py-1 shadow-xl",
   },
 
   variants: {


### PR DESCRIPTION
- Selected item's checkmark was using an icon from a different icon library. Changed it to use the same library as others.
- Removed the `layout` variant from the select component.
- Added a custom scrollbar style for the dropdown.
- Previously the mobile version of the select changed to the desktop version at `sm` media query. It was too early and caused the layout to break as there was no space for all the elements. So changed it to instead change at `md`.
- Enabled the consumer to pass an icon for the mobile version of the select.