### PR TITLE
feat: add transactionType

### DIFF
--- a/prisma/migrations/20250922072749_transaction_type/migration.sql
+++ b/prisma/migrations/20250922072749_transaction_type/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `transactionType` to the `Transaction` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "public"."TransactionType" AS ENUM ('INCOME', 'EXPENSE');
+
+-- AlterTable
+ALTER TABLE "public"."Transaction" ADD COLUMN     "transactionType" "public"."TransactionType" NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,20 @@ model Color {
   pots    Pot[]
 }
 
+model Transaction {
+  id              String         @id @default(cuid())
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
+  user            User           @relation(fields: [userId], references: [id])
+  userId          String
+  counterparty    String
+  category        Category       @relation(fields: [categoryId], references: [id])
+  categoryId      String
+  amount          Decimal        @db.Decimal(12, 2)
+  recurringBill   RecurringBill? @relation(fields: [recurringBillId], references: [id])
+  recurringBillId String?
+}
+
 model Budget {
   id           String   @id @default(cuid())
   createdAt    DateTime @default(now())
@@ -66,20 +80,6 @@ model Pot {
   colorId       String
 
   @@unique([userId, name])
-}
-
-model Transaction {
-  id              String         @id @default(cuid())
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
-  user            User           @relation(fields: [userId], references: [id])
-  userId          String
-  counterparty    String
-  category        Category       @relation(fields: [categoryId], references: [id])
-  categoryId      String
-  amount          Decimal        @db.Decimal(12, 2)
-  recurringBill   RecurringBill? @relation(fields: [recurringBillId], references: [id])
-  recurringBillId String?
 }
 
 model RecurringBill {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,11 @@ datasource db {
   directUrl = env("DIRECT_URL")
 }
 
+enum TransactionType {
+  INCOME
+  EXPENSE
+}
+
 model User {
   id             String          @id @default(cuid())
   name           String
@@ -41,16 +46,17 @@ model Color {
 }
 
 model Transaction {
-  id              String         @id @default(cuid())
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
-  user            User           @relation(fields: [userId], references: [id])
+  id              String          @id @default(cuid())
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+  user            User            @relation(fields: [userId], references: [id])
   userId          String
   counterparty    String
-  category        Category       @relation(fields: [categoryId], references: [id])
+  category        Category        @relation(fields: [categoryId], references: [id])
   categoryId      String
-  amount          Decimal        @db.Decimal(12, 2)
-  recurringBill   RecurringBill? @relation(fields: [recurringBillId], references: [id])
+  amount          Decimal         @db.Decimal(12, 2)
+  transactionType TransactionType
+  recurringBill   RecurringBill?  @relation(fields: [recurringBillId], references: [id])
   recurringBillId String?
 }
 

--- a/src/actions/transactions.ts
+++ b/src/actions/transactions.ts
@@ -22,6 +22,12 @@ export async function createTransaction(
   if (!parsed.success) return z.flattenError(parsed.error).fieldErrors
 
   if (parsed.data.isRecurring) {
+    if (parsed.data.transactionType === "INCOME")
+      return {
+        transactionType: [
+          "When type is INCOME, you cannot set a recurring bill.",
+        ],
+      }
     const recurringBillResponse = await recurringBills.createRecurringBill(
       parsed.data
     )

--- a/src/components/budgets/BudgetCard.tsx
+++ b/src/components/budgets/BudgetCard.tsx
@@ -7,6 +7,7 @@ import { ProgressBar } from "react-aria-components"
 
 import DeleteBudgetDialog from "@/components/budgets/DeleteBudgetDialog"
 import EditBudgetDialog from "@/components/budgets/EditBudgetDialog"
+import TransactionAmount from "@/components/transactions/TransactionAmount"
 import Card from "@/components/ui/Card"
 import Heading from "@/components/ui/Heading"
 import IconButton from "@/components/ui/IconButton"
@@ -129,9 +130,11 @@ export default function BudgetCard({
                 <h4 className="text-grey-900 row-span-2 text-xs leading-normal font-bold">
                   {transaction.counterparty}
                 </h4>
-                <p className="text-grey-900 justify-self-end text-xs leading-normal font-bold">
-                  {currencyFormatter.format(Number(transaction.amount))}
-                </p>
+                <TransactionAmount
+                  transactionAmount={transaction.amount}
+                  transactionType={transaction.transactionType}
+                  className="justify-self-end text-xs"
+                />
                 <p className="text-grey-500 justify-self-end text-xs leading-normal font-normal">
                   {format(transaction.createdAt, "dd MMM yyyy")}
                 </p>

--- a/src/components/overview/TransactionsOverview.tsx
+++ b/src/components/overview/TransactionsOverview.tsx
@@ -2,11 +2,11 @@ import { format } from "date-fns"
 import { PiArrowsDownUpFill } from "react-icons/pi"
 
 import EmptyState from "@/components/empty-states/EmptyState"
+import TransactionAmount from "@/components/transactions/TransactionAmount"
 import Card from "@/components/ui/Card"
 import Heading from "@/components/ui/Heading"
 import Link from "@/components/ui/Link"
 import { getTransactions } from "@/data-access/transactions"
-import { currencyFormatter } from "@/lib/utils"
 
 export default async function TransactionsOverview() {
   const { transactions } = await getTransactions({ take: 5 })
@@ -30,9 +30,14 @@ export default async function TransactionsOverview() {
                 key={transaction.id}
                 className="border-b-grey-100 grid gap-1 border-b py-4 first:pt-0 last:border-none last:pb-0"
               >
-                <div className="text-grey-900 flex items-center justify-between gap-2 text-sm leading-normal font-bold">
-                  <p>{transaction.counterparty}</p>
-                  <p>{currencyFormatter.format(Number(transaction.amount))}</p>
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-grey-900 text-sm leading-normal font-bold">
+                    {transaction.counterparty}
+                  </p>
+                  <TransactionAmount
+                    transactionAmount={transaction.amount}
+                    transactionType={transaction.transactionType}
+                  />
                 </div>
                 <div className="text-grey-500 flex items-center justify-between gap-2 text-xs leading-normal font-normal">
                   <p>{transaction.category.label}</p>

--- a/src/components/transactions/AddTransactionDialog.tsx
+++ b/src/components/transactions/AddTransactionDialog.tsx
@@ -8,9 +8,10 @@ import Button from "@/components/ui/Button"
 import Checkbox from "@/components/ui/Checkbox"
 import { DialogTrigger, Dialog } from "@/components/ui/Dialog"
 import NumberField from "@/components/ui/NumberField"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/RadioGroup"
 import { Select, SelectItem } from "@/components/ui/Select"
 import TextField from "@/components/ui/TextField"
-import { transactionCreateSchema } from "@/lib/schemas"
+import { TransactionCreate, transactionCreateSchema } from "@/lib/schemas"
 
 import type { Category } from "@/data-access/lookups"
 import type { TransactionCreateErrors } from "@/lib/types"
@@ -26,12 +27,13 @@ export default function AddTransactionDialog({
     setError,
     reset,
     formState: { isSubmitting },
-  } = useForm({
+  } = useForm<TransactionCreate>({
     resolver: zodResolver(transactionCreateSchema),
     defaultValues: {
       counterparty: "",
       amount: 0,
       categoryId: "",
+      transactionType: "INCOME",
       isRecurring: false,
     },
   })
@@ -67,6 +69,24 @@ export default function AddTransactionDialog({
               Create a transaction to record your money flow.
             </p>
             <div className="grid gap-4">
+              <Controller
+                name="transactionType"
+                control={control}
+                render={({ field, fieldState: { invalid, error } }) => (
+                  <RadioGroup
+                    label="Transaction Type"
+                    layout="horizontal"
+                    {...field}
+                    isInvalid={invalid}
+                    errorMessage={error?.message}
+                    isDisabled={isSubmitting}
+                  >
+                    <RadioGroupItem value="INCOME">Income</RadioGroupItem>
+                    <RadioGroupItem value="EXPENSE">Expense</RadioGroupItem>
+                  </RadioGroup>
+                )}
+              />
+
               <Controller
                 name="counterparty"
                 control={control}

--- a/src/components/transactions/AddTransactionDialog.tsx
+++ b/src/components/transactions/AddTransactionDialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useForm, Controller } from "react-hook-form"
+import { useForm, Controller, useWatch } from "react-hook-form"
 
 import { createTransaction } from "@/actions/transactions"
 import Button from "@/components/ui/Button"
@@ -36,6 +36,11 @@ export default function AddTransactionDialog({
       transactionType: "INCOME",
       isRecurring: false,
     },
+  })
+
+  const transactionTypeValue = useWatch({
+    control: control,
+    name: "transactionType",
   })
 
   return (
@@ -150,7 +155,14 @@ export default function AddTransactionDialog({
                 name="isRecurring"
                 control={control}
                 render={({ field: { name, value, onChange } }) => (
-                  <Checkbox name={name} isSelected={value} onChange={onChange}>
+                  <Checkbox
+                    name={name}
+                    isSelected={value}
+                    onChange={onChange}
+                    isDisabled={
+                      transactionTypeValue === "INCOME" || isSubmitting
+                    }
+                  >
                     Is this a recurring bill?
                   </Checkbox>
                 )}

--- a/src/components/transactions/TableDesktop.tsx
+++ b/src/components/transactions/TableDesktop.tsx
@@ -8,7 +8,7 @@ import {
 } from "@tanstack/react-table"
 import { format } from "date-fns"
 
-import { currencyFormatter } from "@/lib/utils"
+import TransactionAmount from "@/components/transactions/TransactionAmount"
 
 import type { Transaction } from "@/data-access/transactions"
 
@@ -41,11 +41,17 @@ const columns = [
   }),
   columnHelper.accessor("amount", {
     header: () => <span className="block w-full text-end">Amount</span>,
-    cell: (data) => (
-      <span className="text-grey-900 block w-full text-end text-sm leading-normal font-bold">
-        {currencyFormatter.format(Number(data.getValue()))}
-      </span>
-    ),
+    cell: (data) => {
+      const { amount, transactionType } = data.row.original
+      return (
+        <span className="block w-full text-end">
+          <TransactionAmount
+            transactionAmount={amount}
+            transactionType={transactionType}
+          />
+        </span>
+      )
+    },
   }),
 ]
 

--- a/src/components/transactions/TableMobile.tsx
+++ b/src/components/transactions/TableMobile.tsx
@@ -2,7 +2,7 @@
 
 import { format } from "date-fns"
 
-import { currencyFormatter } from "@/lib/utils"
+import TransactionAmount from "@/components/transactions/TransactionAmount"
 
 import type { Transaction } from "@/data-access/transactions"
 
@@ -18,9 +18,14 @@ export default function TableMobile({
           key={transaction.id}
           className="border-b-grey-100 grid gap-1 border-b py-4 first:pt-0 last:border-none last:pb-0"
         >
-          <div className="text-grey-900 flex items-center justify-between gap-2 text-sm leading-normal font-bold">
-            <p>{transaction.counterparty}</p>
-            <p>{currencyFormatter.format(Number(transaction.amount))}</p>
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-grey-900 text-sm leading-normal font-bold">
+              {transaction.counterparty}
+            </p>
+            <TransactionAmount
+              transactionAmount={transaction.amount}
+              transactionType={transaction.transactionType}
+            />
           </div>
           <div className="text-grey-500 flex items-center justify-between gap-2 text-xs leading-normal font-normal">
             <p>{transaction.category.label}</p>

--- a/src/components/transactions/TransactionAmount.stories.tsx
+++ b/src/components/transactions/TransactionAmount.stories.tsx
@@ -1,0 +1,44 @@
+import TransactionAmount from "@/components/transactions/TransactionAmount"
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite"
+
+const meta = {
+  title: "Components/Transactions/TransactionAmount",
+  component: TransactionAmount,
+  parameters: {
+    layout: "padded",
+  },
+
+  argTypes: {
+    transactionAmount: {
+      description: "Amount of the transaction.",
+      table: { type: { summary: "string | number" } },
+    },
+    transactionType: {
+      description: "Type of the transaction.",
+      table: {
+        type: { summary: '"INCOME" | "EXPENSE"' },
+      },
+      control: "select",
+      options: ["INCOME", "EXPENSE"],
+    },
+  },
+
+  args: {
+    transactionAmount: "450",
+  },
+} satisfies Meta<typeof TransactionAmount>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Income: Story = {
+  args: { transactionType: "INCOME" },
+}
+
+export const Expense: Story = {
+  args: { transactionType: "EXPENSE" },
+}

--- a/src/components/transactions/TransactionAmount.tsx
+++ b/src/components/transactions/TransactionAmount.tsx
@@ -1,17 +1,21 @@
-import { currencyFormatter } from "@/lib/utils"
+import { currencyFormatter, cn } from "@/lib/utils"
 
 export default function TransactionAmount({
   transactionAmount,
   transactionType,
+  className,
 }: {
   transactionAmount: string | number
   transactionType?: "INCOME" | "EXPENSE"
+  className?: string
 }) {
   const amount = currencyFormatter.format(Number(transactionAmount))
 
   if (transactionType === "INCOME") {
     return (
-      <p className="text-green text-sm leading-normal font-bold">
+      <p
+        className={cn("text-green text-sm leading-normal font-bold", className)}
+      >
         {`+${amount}`}
       </p>
     )
@@ -19,13 +23,18 @@ export default function TransactionAmount({
 
   if (transactionType === "EXPENSE") {
     return (
-      <p className="text-red text-sm leading-normal font-bold">
+      <p className={cn("text-red text-sm leading-normal font-bold", className)}>
         {`-${amount}`}
       </p>
     )
   } else {
     return (
-      <p className="text-grey-900 text-sm leading-normal font-bold">
+      <p
+        className={cn(
+          "text-grey-900 text-sm leading-normal font-bold",
+          className
+        )}
+      >
         {`${amount}`}
       </p>
     )

--- a/src/components/transactions/TransactionAmount.tsx
+++ b/src/components/transactions/TransactionAmount.tsx
@@ -1,0 +1,33 @@
+import { currencyFormatter } from "@/lib/utils"
+
+export default function TransactionAmount({
+  transactionAmount,
+  transactionType,
+}: {
+  transactionAmount: string | number
+  transactionType?: "INCOME" | "EXPENSE"
+}) {
+  const amount = currencyFormatter.format(Number(transactionAmount))
+
+  if (transactionType === "INCOME") {
+    return (
+      <p className="text-green text-sm leading-normal font-bold">
+        {`+${amount}`}
+      </p>
+    )
+  }
+
+  if (transactionType === "EXPENSE") {
+    return (
+      <p className="text-red text-sm leading-normal font-bold">
+        {`-${amount}`}
+      </p>
+    )
+  } else {
+    return (
+      <p className="text-grey-900 text-sm leading-normal font-bold">
+        {`${amount}`}
+      </p>
+    )
+  }
+}

--- a/src/components/transactions/TransactionAmount.tsx
+++ b/src/components/transactions/TransactionAmount.tsx
@@ -1,4 +1,6 @@
-import { currencyFormatter, cn } from "@/lib/utils"
+import { tv } from "tailwind-variants"
+
+import { currencyFormatter } from "@/lib/utils"
 
 export default function TransactionAmount({
   transactionAmount,
@@ -9,13 +11,21 @@ export default function TransactionAmount({
   transactionType?: "INCOME" | "EXPENSE"
   className?: string
 }) {
+  const transactionAmountStyles = tv({
+    base: "text-grey-900 text-sm leading-normal font-bold",
+    variants: {
+      transactionType: {
+        INCOME: "text-green",
+        EXPENSE: "text-red",
+      },
+    },
+  })
+
   const amount = currencyFormatter.format(Number(transactionAmount))
 
   if (transactionType === "INCOME") {
     return (
-      <p
-        className={cn("text-green text-sm leading-normal font-bold", className)}
-      >
+      <p className={transactionAmountStyles({ transactionType, className })}>
         {`+${amount}`}
       </p>
     )
@@ -23,20 +33,13 @@ export default function TransactionAmount({
 
   if (transactionType === "EXPENSE") {
     return (
-      <p className={cn("text-red text-sm leading-normal font-bold", className)}>
+      <p className={transactionAmountStyles({ transactionType, className })}>
         {`-${amount}`}
       </p>
     )
   } else {
     return (
-      <p
-        className={cn(
-          "text-grey-900 text-sm leading-normal font-bold",
-          className
-        )}
-      >
-        {`${amount}`}
-      </p>
+      <p className={transactionAmountStyles({ className })}>{`${amount}`}</p>
     )
   }
 }

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -15,7 +15,7 @@ export default function Checkbox({
   return (
     <RacCheckbox
       {...props}
-      className="group flex cursor-pointer items-center gap-2"
+      className="group rac-disabled:opacity-40 rac-disabled:cursor-not-allowed flex cursor-pointer items-center gap-2"
     >
       {({ isSelected }) => (
         <>

--- a/src/components/ui/RadioGroup.stories.tsx
+++ b/src/components/ui/RadioGroup.stories.tsx
@@ -8,11 +8,29 @@ const meta = {
   parameters: {
     layout: "padded",
   },
+
+  argTypes: {
+    label: {
+      description:
+        "Label for the radio group. If a visible label is not provided, an aria-label should be provided.",
+    },
+    layout: {
+      description:
+        "Layout for the radio items. This also controls the `orientation` prop on the radio group.",
+      table: {
+        type: { summary: '"vertical" | "horizontal"' },
+        defaultValue: { summary: '"vertical"' },
+      },
+      control: "select",
+      options: ["vertical", "horizontal"],
+    },
+  },
+
   args: {
     label: "Label",
+    layout: "vertical",
     isDisabled: false,
   },
-  argTypes: {},
 } satisfies Meta<typeof RadioGroup>
 
 export default meta
@@ -22,6 +40,40 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   render: (args) => (
     <RadioGroup {...args}>
+      <RadioGroupItem value="option-1">Option 01</RadioGroupItem>
+      <RadioGroupItem value="option-2">Option 02</RadioGroupItem>
+      <RadioGroupItem value="option-3">Option 03</RadioGroupItem>
+    </RadioGroup>
+  ),
+}
+
+export const HorizontalLayout: Story = {
+  render: (args) => (
+    <RadioGroup {...args} layout="horizontal">
+      <RadioGroupItem value="option-1">Option 01</RadioGroupItem>
+      <RadioGroupItem value="option-2">Option 02</RadioGroupItem>
+      <RadioGroupItem value="option-3">Option 03</RadioGroupItem>
+    </RadioGroup>
+  ),
+}
+
+export const WithErrorMessage: Story = {
+  render: (args) => (
+    <RadioGroup
+      {...args}
+      errorMessage="Radio group error message."
+      isInvalid={true}
+    >
+      <RadioGroupItem value="option-1">Option 01</RadioGroupItem>
+      <RadioGroupItem value="option-2">Option 02</RadioGroupItem>
+      <RadioGroupItem value="option-3">Option 03</RadioGroupItem>
+    </RadioGroup>
+  ),
+}
+
+export const Disabled: Story = {
+  render: (args) => (
+    <RadioGroup {...args} isDisabled={true}>
       <RadioGroupItem value="option-1">Option 01</RadioGroupItem>
       <RadioGroupItem value="option-2">Option 02</RadioGroupItem>
       <RadioGroupItem value="option-3">Option 03</RadioGroupItem>

--- a/src/components/ui/RadioGroup.stories.tsx
+++ b/src/components/ui/RadioGroup.stories.tsx
@@ -1,0 +1,30 @@
+import { RadioGroup, RadioGroupItem } from "@/components/ui/RadioGroup"
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite"
+
+const meta = {
+  title: "Components/UI/RadioGroup",
+  component: RadioGroup,
+  parameters: {
+    layout: "padded",
+  },
+  args: {
+    label: "Label",
+    isDisabled: false,
+  },
+  argTypes: {},
+} satisfies Meta<typeof RadioGroup>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => (
+    <RadioGroup {...args}>
+      <RadioGroupItem value="option-1">Option 01</RadioGroupItem>
+      <RadioGroupItem value="option-2">Option 02</RadioGroupItem>
+      <RadioGroupItem value="option-3">Option 03</RadioGroupItem>
+    </RadioGroup>
+  ),
+}

--- a/src/components/ui/RadioGroup.tsx
+++ b/src/components/ui/RadioGroup.tsx
@@ -70,11 +70,11 @@ function RadioGroupItem({
   ...props
 }: RadioGroupItemProps) {
   return (
-    <RacRadio {...props} className="group">
+    <RacRadio {...props} className="group w-full">
       {({ isSelected }) => (
         <div
           className={cn(
-            "border-beige-500 group-rac-disabled:opacity-40 group-rac-disabled:cursor-not-allowed text-grey-500 group-rac-hover:bg-beige-100 group-rac-selected:ring-1 group-rac-focus-visible:ring-1 group-rac-focus-visible:border-grey-500 group-rac-selected:border-grey-500 ring-grey-500 group-rac-selected:bg-beige-100 relative flex cursor-pointer items-center gap-2 rounded-lg border bg-white px-5 py-3 text-sm leading-normal font-normal transition-[background-color]",
+            "border-beige-500 group-rac-disabled:opacity-40 group-rac-disabled:cursor-not-allowed text-grey-500 group-rac-hover:bg-beige-100 group-rac-focus-visible:ring-2 ring-beige-500 group-rac-selected:bg-beige-300 relative flex cursor-pointer items-center gap-2 rounded-lg border bg-white px-5 py-3 text-sm leading-normal font-normal transition-[background-color]",
             className
           )}
         >

--- a/src/components/ui/RadioGroup.tsx
+++ b/src/components/ui/RadioGroup.tsx
@@ -3,6 +3,7 @@ import {
   Radio as RacRadio,
   RadioGroup as RacRadioGroup,
 } from "react-aria-components"
+import { tv, VariantProps } from "tailwind-variants"
 
 import FieldError from "@/components/ui/FieldError"
 import Label from "@/components/ui/Label"
@@ -14,23 +15,46 @@ import type {
   RadioProps as RacRadioProps,
 } from "react-aria-components"
 
-type RadioGroupProps = Omit<RacRadioGroupProps, "children"> & {
+const radioStyles = tv({
+  slots: {
+    radioItemsWrapper: "flex gap-3",
+  },
+  variants: {
+    layout: {
+      vertical: { radioItemsWrapper: "flex-col" },
+      horizontal: { radioItemsWrapper: "flex-row" },
+    },
+  },
+  defaultVariants: { layout: "vertical" },
+})
+
+const { radioItemsWrapper } = radioStyles()
+
+type RadioVariants = VariantProps<typeof radioStyles>
+
+type RadioGroupProps = Omit<RacRadioGroupProps, "children" | "className"> & {
   label?: string
   children?: ReactNode
   errorMessage?: string
-}
+  className?: string
+} & RadioVariants
 
 function RadioGroup({
   label,
   children,
   className,
-  errorMessage = "Test",
+  errorMessage,
+  layout,
   ...props
 }: RadioGroupProps) {
   return (
-    <RacRadioGroup {...props} className={cn("grid gap-1", className)}>
+    <RacRadioGroup
+      {...props}
+      className={cn("grid gap-1", className)}
+      orientation={layout}
+    >
       <Label>{label}</Label>
-      <div className="grid gap-3">{children}</div>
+      <div className={radioItemsWrapper({ layout })}>{children}</div>
       <FieldError>{errorMessage}</FieldError>
     </RacRadioGroup>
   )
@@ -50,7 +74,7 @@ function RadioGroupItem({
       {({ isSelected }) => (
         <div
           className={cn(
-            "border-beige-500 group-rac-disabled:opacity-40 text-grey-500 group-rac-hover:bg-beige-100 group-rac-selected:ring-1 group-rac-focus-visible:ring-1 group-rac-focus-visible:border-grey-500 group-rac-selected:border-grey-500 ring-grey-500 relative flex cursor-pointer items-center gap-2 rounded-lg border-2 bg-white px-5 py-3 text-sm leading-normal font-normal transition-[background-color]",
+            "border-beige-500 group-rac-disabled:opacity-40 group-rac-disabled:cursor-not-allowed text-grey-500 group-rac-hover:bg-beige-100 group-rac-selected:ring-1 group-rac-focus-visible:ring-1 group-rac-focus-visible:border-grey-500 group-rac-selected:border-grey-500 ring-grey-500 group-rac-selected:bg-beige-100 relative flex cursor-pointer items-center gap-2 rounded-lg border bg-white px-5 py-3 text-sm leading-normal font-normal transition-[background-color]",
             className
           )}
         >

--- a/src/components/ui/RadioGroup.tsx
+++ b/src/components/ui/RadioGroup.tsx
@@ -1,0 +1,83 @@
+import { motion } from "motion/react"
+import {
+  Radio as RacRadio,
+  RadioGroup as RacRadioGroup,
+} from "react-aria-components"
+
+import FieldError from "@/components/ui/FieldError"
+import Label from "@/components/ui/Label"
+import { cn } from "@/lib/utils"
+
+import type { ReactNode } from "react"
+import type {
+  RadioGroupProps as RacRadioGroupProps,
+  RadioProps as RacRadioProps,
+} from "react-aria-components"
+
+type RadioGroupProps = Omit<RacRadioGroupProps, "children"> & {
+  label?: string
+  children?: ReactNode
+  errorMessage?: string
+}
+
+function RadioGroup({
+  label,
+  children,
+  className,
+  errorMessage = "Test",
+  ...props
+}: RadioGroupProps) {
+  return (
+    <RacRadioGroup {...props} className={cn("grid gap-1", className)}>
+      <Label>{label}</Label>
+      <div className="grid gap-3">{children}</div>
+      <FieldError>{errorMessage}</FieldError>
+    </RacRadioGroup>
+  )
+}
+
+type RadioGroupItemProps = Omit<RacRadioProps, "children"> & {
+  children: ReactNode
+}
+
+function RadioGroupItem({
+  children,
+  className,
+  ...props
+}: RadioGroupItemProps) {
+  return (
+    <RacRadio {...props} className="group">
+      {({ isSelected }) => (
+        <div
+          className={cn(
+            "border-beige-500 group-rac-disabled:opacity-40 text-grey-500 group-rac-hover:bg-beige-100 group-rac-selected:ring-1 group-rac-focus-visible:ring-1 group-rac-focus-visible:border-grey-500 group-rac-selected:border-grey-500 ring-grey-500 relative flex cursor-pointer items-center gap-2 rounded-lg border-2 bg-white px-5 py-3 text-sm leading-normal font-normal transition-[background-color]",
+            className
+          )}
+        >
+          <motion.span
+            className="border-grey-500 relative h-5 w-5 shrink-0 rounded-full border-2 bg-white"
+            animate={isSelected ? "selected" : "unSelected"}
+            variants={{
+              selected: { borderColor: "var(--color-beige-500)" },
+              unSelected: { borderColor: "var(--color-beige-500)" },
+            }}
+          >
+            <motion.span
+              className="bg-beige-500 absolute inset-0 rounded-full"
+              initial={{ scale: 0 }}
+              animate={isSelected ? "selected" : "unSelected"}
+              variants={{
+                selected: { scale: 0.7, opacity: 1 },
+                unSelected: { scale: 0, opacity: 0 },
+              }}
+              transition={{ type: "spring", stiffness: 350, damping: 30 }}
+            />
+          </motion.span>
+          {children}
+        </div>
+      )}
+    </RacRadio>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -82,7 +82,7 @@ const {
   fieldErrorMessage,
 } = selectStyles()
 
-type SelectStyles = VariantProps<typeof selectStyles>
+type SelectVariants = VariantProps<typeof selectStyles>
 
 type SelectProps<T extends object> = Omit<
   RacSelectProps<T>,
@@ -97,7 +97,7 @@ type SelectProps<T extends object> = Omit<
   ref?: Ref<HTMLDivElement>
   className?: string
   mobileIcon?: IconType
-} & SelectStyles
+} & SelectVariants
 
 function Select<T extends object>({
   label,

--- a/src/data-access/transactions.ts
+++ b/src/data-access/transactions.ts
@@ -14,9 +14,15 @@ import type { TransactionCreateErrors, DALReturn } from "@/lib/types"
 // ============ Create Transaction ============
 // ============================================
 
-export async function createTransaction(
-  formData: TransactionCreate & { recurringBillId?: string }
-): Promise<DALReturn<TransactionCreateErrors>> {
+export async function createTransaction({
+  counterparty,
+  amount,
+  categoryId,
+  transactionType,
+  recurringBillId,
+}: TransactionCreate & { recurringBillId?: string }): Promise<
+  DALReturn<TransactionCreateErrors>
+> {
   const userId = await verifySession()
   if (!userId) redirect("/login")
 
@@ -24,10 +30,11 @@ export async function createTransaction(
     await prisma.transaction.create({
       data: {
         userId,
-        counterparty: formData.counterparty,
-        amount: formData.amount,
-        categoryId: formData.categoryId,
-        recurringBillId: formData.recurringBillId,
+        counterparty,
+        amount,
+        categoryId,
+        transactionType,
+        recurringBillId: recurringBillId,
       },
     })
     return { success: true }

--- a/src/data-access/transactions.ts
+++ b/src/data-access/transactions.ts
@@ -59,6 +59,7 @@ const transactionSelect = {
   counterparty: true,
   amount: true,
   category: true,
+  transactionType: true,
 } satisfies Prisma.TransactionSelect
 
 type GetTransactionsParams = {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -38,6 +38,10 @@ export const transactionCreateSchema = z.object({
     .number("Amount cannot be empty.")
     .nonnegative("Amount cannot be negative."),
   categoryId: z.cuid("Please select a category."),
+  transactionType: z.enum(
+    ["INCOME", "EXPENSE"],
+    "Please pick a transaction type."
+  ),
   isRecurring: z.boolean(),
 })
 export type TransactionCreate = z.infer<typeof transactionCreateSchema>


### PR DESCRIPTION
- Added a RadioGroup component.
- Updated the prisma schema to include `transactionType` field in the `Transaction` table.
- Updated transaction create form to include a radio group, so user can pick the transaction type.
- Added a TransactionAmount component to render the formatted and styled number when the amount and transaction type is given.