### PR TITLE
storybook: pagination story

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -27,6 +27,9 @@ const preview: Preview = {
       },
     },
     viewport: { options: { ...MINIMAL_VIEWPORTS, ...customViewports } },
+    nextjs: {
+      appDirectory: true,
+    },
   },
 
   initialGlobals: {

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers"
 
-import { Navbar } from "@/components/ui/Navbar"
+import Navbar from "@/components/ui/Navbar"
 import { publicSans } from "@/lib/fonts"
 
 import "../globals.css"

--- a/src/components/ui/Link.stories.tsx
+++ b/src/components/ui/Link.stories.tsx
@@ -6,7 +6,7 @@ const meta = {
   title: "Components/UI/Link",
   component: Link,
   args: {
-    href: "/",
+    href: "#",
     children: "This is a Link",
     withIcon: false,
   },

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -70,7 +70,7 @@ const NavbarContext = createContext<NavbarContextType>({
   isExpanded: undefined,
 })
 
-function Navbar({
+export default function Navbar({
   initialExpanded,
   className,
 }: {
@@ -181,5 +181,3 @@ function NavbarItem({
     </li>
   )
 }
-
-export { Navbar, NavbarItem }

--- a/src/components/ui/Pagination.stories.tsx
+++ b/src/components/ui/Pagination.stories.tsx
@@ -1,0 +1,17 @@
+import Pagination from "@/components/ui/Pagination"
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite"
+
+const meta = {
+  title: "Components/UI/Pagination",
+  component: Pagination,
+} satisfies Meta<typeof Pagination>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  parameters: { nextjs: { navigation: { query: { page: 1 } } } },
+  args: { totalPages: 10 },
+}


### PR DESCRIPTION
- Bug: Clicking on a Pagination link item inside Storybook will change the Storybook URL and break Storybook. Couldn’t find a way to stop that from happening when clicked on a Pagination item.